### PR TITLE
Do not require angle brackets in `argument`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ main = do
   args <- optionsWithUsageFile "USAGE.txt"
 
   when (args `isPresent` (command "cat")) $ do
-    file <- args `getArg` (argument "<file>")
+    file <- args `getArg` (argument "file")
     putStr =<< readFile file
 
   when (args `isPresent` (command "echo")) $ do
     let charTransform = if args `isPresent` (longOption "caps")
                           then toUpper
                           else id
-    string <- args `getArg` (argument "<string>")
+    string <- args `getArg` (argument "string")
     putStrLn $ map charTransform string
 
 ```

--- a/System/Console/Docopt/UsageParse.hs
+++ b/System/Console/Docopt/UsageParse.hs
@@ -93,7 +93,7 @@ pArgument = (try bracketStyle) <|> (try upperStyle)
                       open <- char '<' 
                       name <- many $ oneOf alphanumSpecial
                       close <- char '>'
-                      return $ [open]++name++[close]
+                      return name
                   upperStyle = do 
                       first <- oneOf uppers
                       rest <- many $ oneOf $ uppers ++ numerics

--- a/examples/Naval_fate.hs
+++ b/examples/Naval_fate.hs
@@ -16,18 +16,18 @@ main = do
 		putStrLn "Command 'ship'"
 		when (opts `isPresent` (command "new")) $ do
 			putStrLn "  Command 'new'"
-			name <- opts `getAllArgsM` (argument "<name>")
+			name <- opts `getAllArgsM` (argument "name")
 			putStrLn $ "  <name> " ++ show name
 		when (opts `isPresent` (command "shoot")) $ do
 			putStrLn "  Command 'shoot'"
-			x <- (opts `getArg` (argument "<x>"))
+			x <- (opts `getArg` (argument "x"))
 			putStrLn $ "  <x> " ++ show x
-			y <- (opts `getArg` (argument "<y>"))
+			y <- (opts `getArg` (argument "y"))
 			putStrLn $ "  <y> " ++ show y
 		when (opts `isPresent` (command "move")) $ do
-			x <- opts `getArg` (argument "<x>")
-			y <- opts `getArg` (argument "<y>")
-			name <- opts `getArg` (argument "<name>")
+			x <- opts `getArg` (argument "x")
+			y <- opts `getArg` (argument "y")
+			name <- opts `getArg` (argument "name")
 			speed <- opts `getArg` (longOption "speed")
 			putStrLn $ "<name> " ++ show name
 			putStrLn "  Command 'move'"
@@ -41,8 +41,8 @@ main = do
 				putStrLn "  Command 'set'"
 			when (opts `isPresent` (command "remove")) $ do
 				putStrLn "  Command 'remove'"
-			x <- opts `getArg` (argument "<x>")
-			y <- opts `getArg` (argument "<y>")
+			x <- opts `getArg` (argument "x")
+			y <- opts `getArg` (argument "y")
 			putStrLn $ "  <x> " ++ show x		
 			putStrLn $ "  <y> " ++ show y
 		when (opts `isPresent` (command "list")) $ do


### PR DESCRIPTION
From [ryanartecona's comment on issue #4](https://github.com/docopt/docopt.hs/pull/4#issuecomment-46645331):

> Having to specify the angle brackets in an argument lookup does feel like a mistake, though.

Thought so, too! That turned out to be trivial to fix.

If you merge this, I can open an issue so you don't forget to make a new release once you get back from your vacation. Have a good time!
