### PR TITLE
Enable parsing of usage strings at compile time

### DIFF
--- a/Docopt.cabal
+++ b/Docopt.cabal
@@ -7,7 +7,7 @@ license:             MIT
 license-file:        LICENSE.txt
 author:              Ryan Artecona
 maintainer:          ryanartecona@gmail.com
-copyright:           (c) 2013 Ryan Artecona 
+copyright:           (c) 2013 Ryan Artecona
 
 stability:           Experimental
 category:            Console
@@ -18,9 +18,14 @@ cabal-version:       >=1.8
 homepage:            https://github.com/docopt/docopt.hs
 bug-reports:         https://github.com/docopt/docopt.hs/issues
 
+flag template-haskell
+  default:      True
+  description:
+    Build System.Console.Docopt.QQ, which requires Template Haskell
+
 library
   exposed-modules:    System.Console.Docopt
- 
+
   other-modules:      System.Console.Docopt.ApplicativeParsec
                       System.Console.Docopt.ParseUtils
                       System.Console.Docopt.Types
@@ -31,6 +36,12 @@ library
   build-depends:      base == 4.*,
                       parsec == 3.1.*,
                       containers
+
+  if impl(ghc >= 6.10) && flag(template-haskell)
+    exposed-modules:  System.Console.Docopt.QQ
+    other-modules:    System.Console.Docopt.QQ.Instances
+                      System.Console.Docopt.QQ.Util
+    build-depends:    template-haskell == 2.7.*, th-lift == 0.6.*
 
 test-suite tests
   type:               exitcode-stdio-1.0

--- a/System/Console/Docopt/QQ.hs
+++ b/System/Console/Docopt/QQ.hs
@@ -86,8 +86,8 @@ docoptExp usg = do
 -- docopt-sample version 0.1.0
 -- 
 -- Usage:
---   docopt-sample cat <file>
---   docopt-sample echo [--caps] <string>
+--   docopt-sample cat \<file\>
+--   docopt-sample echo [--caps] \<string\>
 -- 
 -- Options:
 --   -c, --caps    Caps-lock the echoed argument

--- a/System/Console/Docopt/QQ.hs
+++ b/System/Console/Docopt/QQ.hs
@@ -18,8 +18,8 @@
 -- docopt-sample version 0.1.0
 -- 
 -- Usage:
---   docopt-sample cat <file>
---   docopt-sample echo [--caps] <string>
+--   docopt-sample cat \<file\>
+--   docopt-sample echo [--caps] \<string\>
 -- 
 -- Options:
 --   -c, --caps    Caps-lock the echoed argument
@@ -29,15 +29,15 @@
 -- main = do
 --   args <- parseArgs' patterns
 -- 
---   when (args \`isPresent\` (command "cat")) $ do
---     file <- args \`getArg\` (argument "file")
+--   when (args \`isPresent\` (command \"cat\")) $ do
+--     file <- args \`getArg\` (argument \"file\")
 --     putStr =<< readFile file
 -- 
---   when (args \`isPresent\` (command "echo")) $ do
---     let charTransform = if args \`isPresent\` (longOption "caps")
+--   when (args \`isPresent\` (command \"echo\")) $ do
+--     let charTransform = if args \`isPresent\` (longOption \"caps\")
 --                         then toUpper
 --                         else id
---     string <- args \`getArg\` (argument "string")
+--     string <- args \`getArg\` (argument \"string\")
 --     putStrLn $ map charTransform string
 -- @
 module System.Console.Docopt.QQ

--- a/System/Console/Docopt/QQ.hs
+++ b/System/Console/Docopt/QQ.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+-- | Template Haskell 'QuasiQuoter's which enable compile time parsing
+-- of usage strings.
+--
+-- Example:
+--
+-- @
+-- {-\# LANGUAGE QuasiQuotes \#-}
+-- module Main where
+-- 
+-- import Control.Monad (when)
+-- import Data.Char (toUpper)
+-- import System.Console.Docopt.QQ
+-- 
+-- patterns :: Docopt
+-- patterns = [docopt|
+-- docopt-sample version 0.1.0
+-- 
+-- Usage:
+--   docopt-sample cat <file>
+--   docopt-sample echo [--caps] <string>
+-- 
+-- Options:
+--   -c, --caps    Caps-lock the echoed argument
+-- |]
+-- 
+-- main :: IO ()
+-- main = do
+--   args <- parseArgs' patterns
+-- 
+--   when (args \`isPresent\` (command "cat")) $ do
+--     file <- args \`getArg\` (argument "file")
+--     putStr =<< readFile file
+-- 
+--   when (args \`isPresent\` (command "echo")) $ do
+--     let charTransform = if args \`isPresent\` (longOption "caps")
+--                         then toUpper
+--                         else id
+--     string <- args \`getArg\` (argument "string")
+--     putStrLn $ map charTransform string
+-- @
+module System.Console.Docopt.QQ
+    ( module System.Console.Docopt
+
+    -- * QuasiQuoters
+    , docopt
+    , docoptFile
+
+    -- * Parsed usage string
+    , Docopt ()
+    , usage
+
+    -- * Command line arguments parsers
+    , parseArgs
+    , parseArgs'
+    ) where
+
+import System.Console.Docopt hiding ( optionsWithUsage
+                                    , optionsWithUsageDebug
+                                    , optionsWithUsageFile
+                                    , optionsWithUsageFileDebug
+                                    )
+import System.Console.Docopt.QQ.Util
+import System.Console.Docopt.QQ.Instances ()
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+docoptExp :: String -> Q Exp
+docoptExp usg = do
+  let mkDocopt fmt = Docopt { usage = usg, optFormat = fmt }
+  loc <- loc_filename <$> location
+  case mkDocopt <$> parseFmt loc usg of
+    Left err     -> fail $ show err
+    Right parser -> [| parser |]
+
+-- | A 'QuasiQuoter' which parses a usage string and returns a
+-- 'Docopt'.
+--
+-- Example usage:
+--
+-- @
+-- patterns :: Docopt
+-- patterns = [docopt|
+-- docopt-sample version 0.1.0
+-- 
+-- Usage:
+--   docopt-sample cat <file>
+--   docopt-sample echo [--caps] <string>
+-- 
+-- Options:
+--   -c, --caps    Caps-lock the echoed argument
+-- |]
+-- @
+docopt :: QuasiQuoter
+docopt = QuasiQuoter { quoteExp  = docoptExp
+                     , quoteDec  = unsupported "Declaration"
+                     , quotePat  = unsupported "Pattern"
+                     , quoteType = unsupported "Type"
+                     }
+    where unsupported = fail . (++ " context unsupported")
+
+-- | Same as 'docopt', but parses the given file instead of a literal
+-- string.
+--
+-- Example:
+--
+-- @
+-- patterns :: Docopt
+-- patterns = [docoptFile|USAGE|]
+-- @
+--
+-- where @USAGE@ is the name of a file which contains the usage
+-- string.
+docoptFile :: QuasiQuoter
+docoptFile = quoteFile docopt

--- a/System/Console/Docopt/QQ/Instances.hs
+++ b/System/Console/Docopt/QQ/Instances.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK hide, prune #-}
+module System.Console.Docopt.QQ.Instances where
+
+import System.Console.Docopt.QQ.Util
+import Language.Haskell.TH.Lift
+
+import qualified Data.Map as M
+
+instance (Lift k, Lift v) => Lift (M.Map k v) where
+    lift m = [| M.fromList assoc |]
+        where assoc = M.toList m
+
+$(deriveLiftMany [ ''Option
+                 , ''Pattern
+                 , ''OptionInfo
+                 , ''Docopt
+                 ])

--- a/System/Console/Docopt/QQ/Util.hs
+++ b/System/Console/Docopt/QQ/Util.hs
@@ -1,0 +1,33 @@
+{-# OPTIONS_HADDOCK hide, prune #-}
+module System.Console.Docopt.QQ.Util
+    ( module System.Console.Docopt.QQ.Util
+    , module System.Console.Docopt.Types
+    , module System.Console.Docopt.ApplicativeParsec
+    ) where
+
+import System.Environment
+
+import System.Console.Docopt.Types
+import System.Console.Docopt.UsageParse
+import System.Console.Docopt.OptParse
+
+import qualified Data.Map as M
+
+import System.Console.Docopt.ApplicativeParsec
+
+-- | An abstract data type which represents Docopt usage patterns.
+data Docopt = Docopt { optFormat :: OptFormat
+                     -- | Retrieve the original usage string.
+                     , usage :: String
+                     }
+
+parseFmt :: FilePath -> String -> Either ParseError OptFormat
+parseFmt = runParser pDocopt M.empty
+
+-- | Parse command line arguments.
+parseArgs :: Docopt -> IO (Either ParseError Arguments)
+parseArgs parser = getArguments (optFormat parser) <$> getArgs
+
+-- | Same as 'parseArgs', but throw an error on failure.
+parseArgs' :: Docopt -> IO Arguments
+parseArgs' parser = either (error . show) id <$> parseArgs parser


### PR DESCRIPTION
This pull requests introduces the module `System.Console.Docopt.QQ` which exports two `QuasiQuoter`s: `docopt` and `docoptFile`. `docopt` parses a literal string &mdash; usage string &mdash; into some abstract data type (a wrapper around `OptFormat`); `docoptFile` takes a file and parses its contents. Parsing is done at the compile time, which means an invalid usage string will result in a  compile time error.

Example from Readme:

``` haskell
{-# LANGUAGE QuasiQuotes #-}
module Main where

import Control.Monad (when)
import Data.Char (toUpper)
import System.Console.Docopt.QQ

patterns :: Docopt
patterns = [docopt|
Usage:
  myprog cat <file>
  myprog echo [--caps] <string>

Options:
  -c, --caps    Caps-lock the echoed argument
|]

main :: IO ()
main = do
  args <- parseArgs' patterns

  when (args `isPresent` (command "cat")) $ do
    file <- args `getArg` (argument "file")
    putStr =<< readFile file

  when (args `isPresent` (command "echo")) $ do
    let charTransform = if args `isPresent` (longOption "caps")
                          then toUpper
                          else id
    string <- args `getArg` (argument "string")
    putStrLn $ map charTransform string

```

See docs for `System.Console.Docopt.QQ` for more info.