### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ main = do
   args <- optionsWithUsageFile "USAGE.txt"
 
   when (args `isPresent` (command "cat")) $ do
-    file <- args `getArg` (argument "file")
+    file <- args `getArg` (argument "<file>")
     putStr =<< readFile file
 
   when (args `isPresent` (command "echo")) $ do
     let charTransform = if args `isPresent` (longOption "caps")
                           then toUpper
                           else id
-    string <- args `getArg` (argument "string")
+    string <- args `getArg` (argument "<string>")
     putStrLn $ map charTransform string
 
 ```


### PR DESCRIPTION
These doesn't work:

    file <- args `getArg` (argument "file")
    ...
    string <- args `getArg` (argument "string")

you have to use exactly the same name given in the usage file or remove the
angle brackets from the <file> and <string> names.

This works:

    file <- args `getArg` (argument "<file>")
    ...
    string <- args `getArg` (argument "<string>")