### PR TITLE
Fixed example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then, in your `Myprog.hs`:
 
 ```haskell
 {-# LANGUAGE QuasiQuotes #-}
+
 import Control.Monad (when)
 import Data.Char (toUpper)
 import System.Environment (getArgs)
@@ -30,20 +31,20 @@ import System.Console.Docopt
 patterns :: Docopt
 patterns = [docoptFile|USAGE.txt|]
 
-getArgOrDie = getArgOrDieWith patterns
+getArgOrExit = getArgOrExitWith patterns
 
 main = do
-  args <- parseArgsOrDie patterns =<< getArgs
+  args <- parseArgsOrExit patterns =<< getArgs
 
   when (args `isPresent` (command "cat")) $ do
-    file <- args `getArgOrDieWith` (argument "file")
+    file <- args `getArgOrExit` (argument "file")
     putStr =<< readFile file
 
   when (args `isPresent` (command "echo")) $ do
     let charTransform = if args `isPresent` (longOption "caps")
                           then toUpper
                           else id
-    string <- args `getArgOrDieWith` (argument "string")
+    string <- args `getArgOrExit` (argument "string")
     putStrLn $ map charTransform string
 ```
 


### PR DESCRIPTION
The original code has errors, maybe due to an older version of Docopt:

```
$ runhaskell test.hs 

test.hs:19:15:
    Not in scope: ‘getArgOrDieWith’
    Perhaps you meant one of these:
      ‘getArgOrExitWith’ (imported from System.Console.Docopt),
      ‘getArgOrDie’ (line 19)

test.hs:22:11:
    Not in scope: ‘parseArgsOrDie’
    Perhaps you meant ‘parseArgsOrExit’ (imported from System.Console.Docopt)

test.hs:25:18:
    Not in scope: ‘getArgOrDieWith’
    Perhaps you meant one of these:
      ‘getArgOrExitWith’ (imported from System.Console.Docopt),
      ‘getArgOrDie’ (line 19)

test.hs:32:20:
    Not in scope: ‘getArgOrDieWith’
    Perhaps you meant one of these:
      ‘getArgOrExitWith’ (imported from System.Console.Docopt),
      ‘getArgOrDie’ (line 19)
```
