### PR TITLE
Remove upper bound on template-haskell

### DIFF
--- a/System/Console/Docopt/QQ/Instances.hs
+++ b/System/Console/Docopt/QQ/Instances.hs
@@ -2,6 +2,10 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 
+-- Needed to compile under current GHC but deprecated. To fix this in future, see
+-- https://downloads.haskell.org/~ghc/7.10.1/docs/html/users_guide/type-class-extensions.html#instance-overlap
+{-# LANGUAGE OverlappingInstances #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_HADDOCK hide, prune #-}
 

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -57,7 +57,7 @@ library
     exposed-modules:  System.Console.Docopt
     other-modules:    System.Console.Docopt.QQ
                       System.Console.Docopt.QQ.Instances
-    build-depends:    template-haskell >= 2.15.0 && < 2.18
+    build-depends:    template-haskell >= 2.15.0
 
   default-language:   Haskell2010
 
@@ -83,7 +83,7 @@ test-suite tests
                       aeson,
                       bytestring,
                       text,
-                      template-haskell >= 2.15.0 && < 2.18
+                      template-haskell >= 2.15.0
 
 
   other-modules:      System.Console.Docopt


### PR DESCRIPTION
I had to remove the upper boundary for template-haskell. It builds with 2.19.* as well.

Can we merge that and publish it on hackage? Current version of template-haskell is already 2.25.