### PR TITLE
Support template-haskell and tests on GHC < 8.8

### DIFF
--- a/System/Console/Docopt/Public.hs
+++ b/System/Console/Docopt/Public.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module System.Console.Docopt.Public
   (
     -- * Command line arguments parsers
@@ -41,6 +43,10 @@ module System.Console.Docopt.Public
   where
 
 import System.Exit
+
+#if !MIN_VERSION_base(4,13,0)
+import Control.Monad.Fail (MonadFail)
+#endif
 
 import Data.Map as M hiding (null)
 import Data.Maybe (fromMaybe)

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -45,7 +45,7 @@ library
 
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
-                      containers >= 0.6.2 && < 0.7
+                      containers >= 0.6.2 && < 0.6.6
 
   ghc-options:        -Wall
                       -fno-warn-unused-binds
@@ -57,7 +57,7 @@ library
     exposed-modules:  System.Console.Docopt
     other-modules:    System.Console.Docopt.QQ
                       System.Console.Docopt.QQ.Instances
-    build-depends:    template-haskell >= 2.15.0 && < 2.18
+    build-depends:    template-haskell >= 2.11.0 && < 2.18
 
   default-language:   Haskell2010
 
@@ -74,17 +74,16 @@ test-suite tests
                       -fno-warn-orphans
 
   build-depends:      base,
-                      parsec >= 3.1.14 && < 3.2,
-                      containers >= 0.6.2 && < 0.7,
+                      parsec,
+                      containers,
                       docopt,
                       HUnit,
                       split,
-                      ansi-terminal,
+                      ansi-terminal >= 0.4,
                       aeson,
                       bytestring,
                       text,
-                      template-haskell >= 2.15.0 && < 2.18
-
+                      template-haskell >= 2.11.0 && < 2.18
 
   other-modules:      System.Console.Docopt
                       System.Console.Docopt.ApplicativeParsec


### PR DESCRIPTION
We can effortlessly support GHC 8.0+ instead of GHC 8.8+ for both building and testing, so let's do that.

GHC's before 8.8 (base-4.13) don't export `MonadFail` to Prelude.

Relax the bounds on `template-haskell` to support GHC 8.0+

Tighten the bounds on `containers` and `ansi-terminal` to exclude unsupported versions.

Drop bounds specification in the test suite for dependencies shared with the library; the library already constrains these dependencies and it reduces maintenance burden.

This was tested with all major GHC versions between 8.0 and 9.0 inclusive, with `cabal v2-test {,--prefer-oldest}`. I also checked the examples on GHC 8.0.

To test with `--prefer-oldest`, you'll need this in `cabal.project.local` since older versions of these packages do not build with GHC 8:
```
constraints:
  aeson >= 1.4.4.0,
  contravariant >= 1.5.2
```

We intend to add CI, but right now I'm focussing on getting this into Stackage. This is a preparation for that, just cleaning up some loose ends.