### PR TITLE
Support newer `containers` and GHC

### DIFF
--- a/System/Console/Docopt/QQ/Instances.hs
+++ b/System/Console/Docopt/QQ/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift#-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -9,7 +10,10 @@ module System.Console.Docopt.QQ.Instances where
 
 import System.Console.Docopt.Types
 import Language.Haskell.TH.Syntax (Lift)
-import Data.Map.Internal (Map(..))
 
+#if !MIN_VERSION_containers(0,6,6)
+import Data.Map.Internal (Map(..))
 deriving instance Lift (Map Option OptionInfo)
+#endif
+
 deriving instance Lift (Docopt)

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -27,14 +27,9 @@ source-repository head
   type:       git
   location:   https://github.com/docopt/docopt.hs.git
 
-flag template-haskell
-  default:      True
-  manual:       True
-  description:
-    Build with QuasiQuoter usage parsers, which requires Template Haskell
-
 library
   exposed-modules:    System.Console.Docopt.NoTH
+                      System.Console.Docopt
 
   other-modules:      System.Console.Docopt.ApplicativeParsec
                       System.Console.Docopt.ParseUtils
@@ -42,22 +37,19 @@ library
                       System.Console.Docopt.UsageParse
                       System.Console.Docopt.OptParse
                       System.Console.Docopt.Public
+                      System.Console.Docopt.QQ
+                      System.Console.Docopt.QQ.Instances
 
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
-                      containers >= 0.6.2 && < 0.6.6
+                      containers >= 0.6.2 && < 0.6.6,
+                      template-haskell >= 2.11.0 && < 2.18
 
   ghc-options:        -Wall
                       -fno-warn-unused-binds
                       -fno-warn-unused-do-bind
                       -fno-warn-unused-matches
                       -fno-warn-name-shadowing
-
-  if impl(ghc >= 6.10) && flag(template-haskell)
-    exposed-modules:  System.Console.Docopt
-    other-modules:    System.Console.Docopt.QQ
-                      System.Console.Docopt.QQ.Instances
-    build-depends:    template-haskell >= 2.11.0 && < 2.18
 
   default-language:   Haskell2010
 
@@ -83,7 +75,7 @@ test-suite tests
                       aeson,
                       bytestring,
                       text,
-                      template-haskell >= 2.11.0 && < 2.18
+                      template-haskell
 
   other-modules:      System.Console.Docopt
                       System.Console.Docopt.ApplicativeParsec

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -42,8 +42,8 @@ library
 
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
-                      containers >= 0.6.2 && < 0.6.6,
-                      template-haskell >= 2.11.0 && < 2.18
+                      containers >= 0.6.2 && < 0.7,
+                      template-haskell >= 2.11.0 && < 2.22
 
   ghc-options:        -Wall
                       -fno-warn-unused-binds

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,10 +2,11 @@
 # http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # ghc 8.10.7
-resolver: lts-18.10
-# ghc 9.0.1
-# resolver: nightly-2021-07-16
-
+# resolver: lts-18.10
+# ghc 9.6.1
+resolver: lts-22.11
+# ghc 9.8.1
+# resolver: nightly-2024-02-22
 packages:
   - '.'
   - examples/


### PR DESCRIPTION
Closes: #54

This should make the package fit for Stackage again \o/

Tested with `cabal v2-test {,--prefer-oldest}` on all GHC's from 8.0 to 9.8 (that's 22 scenario's), plus Stack on LTS-22.11 (GHC 9.6) and `nightly-2024-02-22` (GHC 9.8).