### PR TITLE
Raise version bounds for `containers`

### DIFF
--- a/.ci/cabal.project.local-upper
+++ b/.ci/cabal.project.local-upper
@@ -35,3 +35,9 @@ constraints:
   ghc-prim installed,
   integer-gmp installed,
   template-haskell installed
+
+allow-newer:
+  containers,
+
+constraints:
+  containers == 0.7,

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -42,7 +42,7 @@ library
 
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
-                      containers >= 0.6.2 && < 0.7,
+                      containers >= 0.6.2 && < 0.8,
                       template-haskell >= 2.11.0 && < 2.22
 
   ghc-options:        -Wall -Wno-name-shadowing


### PR DESCRIPTION
We need `--allow-newer` to actually use that version, so we only test it in `HEAD.hackage`.

But it works fine then.