### PR TITLE
Support GHC 9.10

### DIFF
--- a/.ci/stack-9.4.yaml
+++ b/.ci/stack-9.4.yaml
@@ -1,3 +1,3 @@
-resolver: lts-21.14
+resolver: lts-21.25
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.ci/stack-9.6.yaml
+++ b/.ci/stack-9.6.yaml
@@ -1,3 +1,3 @@
-resolver: lts-22.11
+resolver: lts-22.23
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.ci/stack-9.8.yaml
+++ b/.ci/stack-9.8.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2024-02-24
+resolver: nightly-2024-05-31
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,17 +84,17 @@ jobs:
           - "8.8.4"
           - "8.10.7"
           - "9.0.2"
-          - "9.0.2"
           - "9.2.8"
-          - "9.4.7"
-          - "9.6.3"
-          - "9.8.1"
+          - "9.4.8"
+          - "9.6.5"
+          - "9.8.2"
+          - "9.10.1"
         project-variant: [""]
         include:
           - ghc: 8.0.2
             project-variant: -lower
-          - ghc: 9.8.1
-            project-variant: -upper
+          # - ghc: 9.10.1
+          #   project-variant: -upper
 
       fail-fast: false
     steps:

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -17,9 +17,10 @@ tested-with:
   GHC == 8.10.7,
   GHC == 9.0.2,
   GHC == 9.2.8,
-  GHC == 9.4.7,
-  GHC == 9.6.3,
-  GHC == 9.8.1
+  GHC == 9.4.8,
+  GHC == 9.6.5,
+  GHC == 9.8.2,
+  GHC == 9.10.1
 
 category:            Console
 
@@ -42,7 +43,7 @@ source-repository head
 source-repository this
   type:       git
   location:   https://github.com/docopt/docopt.hs.git
-  tag:        v0.7.0.8
+  tag:        v0.7.0.8+r1
 
 library
   exposed-modules:    System.Console.Docopt.NoTH
@@ -60,7 +61,7 @@ library
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
                       containers >= 0.6.2 && < 0.8,
-                      template-haskell >= 2.11.0 && < 2.22
+                      template-haskell >= 2.11.0 && < 2.23
 
   ghc-options:        -Wall -Wno-name-shadowing
 


### PR DESCRIPTION
And bump all CI tests to the latest minor versions

We checked Cabal/9.0.2 twice in CI, fixed

The build plan for HEAD.hackage is identical to the regular build plan for GHC 9.10.1, so the `-upper` CI test is currently disabled as it would merely duplicate the regular test.