### PR TITLE
Support GHC 9.12

### DIFF
--- a/.ci/cabal.project.local-upper
+++ b/.ci/cabal.project.local-upper
@@ -40,4 +40,4 @@ allow-newer:
   containers,
 
 constraints:
-  containers == 0.7,
+  containers == 0.8,

--- a/.ci/stack-9.10.yaml
+++ b/.ci/stack-9.10.yaml
@@ -1,3 +1,3 @@
-resolver: lts-23.11
+resolver: nightly-2025-03-06
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.ci/stack-9.6.yaml
+++ b/.ci/stack-9.6.yaml
@@ -1,3 +1,3 @@
-resolver: lts-22.23
+resolver: lts-22.43
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # TODO: "8.0", "8.2", "8.4", "8.6"
-        ghc: ["8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8"]
+        ghc: ["8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -86,15 +86,16 @@ jobs:
           - "9.0.2"
           - "9.2.8"
           - "9.4.8"
-          - "9.6.5"
-          - "9.8.2"
+          - "9.6.6"
+          - "9.8.4"
           - "9.10.1"
+          - "9.12.1"
         project-variant: [""]
         include:
           - ghc: 8.0.2
             project-variant: -lower
-          # - ghc: 9.10.1
-          #   project-variant: -upper
+          - ghc: 9.12.1
+            project-variant: -upper
 
       fail-fast: false
     steps:

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -18,9 +18,10 @@ tested-with:
   GHC == 9.0.2,
   GHC == 9.2.8,
   GHC == 9.4.8,
-  GHC == 9.6.5,
-  GHC == 9.8.2,
-  GHC == 9.10.1
+  GHC == 9.6.6,
+  GHC == 9.8.4,
+  GHC == 9.10.1,
+  GHC == 9.12.1
 
 category:            Console
 
@@ -43,7 +44,7 @@ source-repository head
 source-repository this
   type:       git
   location:   https://github.com/docopt/docopt.hs.git
-  tag:        v0.7.0.8+r1
+  tag:        v0.7.0.8+r2
 
 library
   exposed-modules:    System.Console.Docopt.NoTH
@@ -60,8 +61,8 @@ library
 
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
-                      containers >= 0.6.2 && < 0.8,
-                      template-haskell >= 2.11.0 && < 2.23
+                      containers >= 0.6.2 && < 0.9,
+                      template-haskell >= 2.11.0 && < 2.24
 
   ghc-options:        -Wall -Wno-name-shadowing
 


### PR DESCRIPTION
and bump bounds on `containers` as well.

Bump all Stack and GHC versions to their latest minors.