### PR TITLE
Support GHC 9.14

### DIFF
--- a/.ci/cabal.project.local-upper
+++ b/.ci/cabal.project.local-upper
@@ -36,8 +36,6 @@ constraints:
   integer-gmp installed,
   template-haskell installed
 
-allow-newer:
-  containers,
-
 constraints:
-  containers == 0.8,
+  attoparsec >= 0.14.4,
+  hashable >= 1.4.0.1,

--- a/.ci/stack-9.10.yaml
+++ b/.ci/stack-9.10.yaml
@@ -1,3 +1,3 @@
-resolver: nightly-2025-03-06
+resolver: lts-24.26
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.ci/stack-9.12.yaml
+++ b/.ci/stack-9.12.yaml
@@ -1,3 +1,3 @@
-resolver: lts-22.44
+resolver: nightly-2025-12-30
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.ci/stack-9.8.yaml
+++ b/.ci/stack-9.8.yaml
@@ -1,3 +1,3 @@
-resolver: lts-23.11
+resolver: lts-23.28
 ghc-options:
   "$locals": -Werror -Wall -Wcompat -Wno-name-shadowing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         # TODO: "8.0", "8.2", "8.4", "8.6"
-        ghc: ["8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10"]
+        ghc: ["8.8", "8.10", "9.0", "9.2", "9.4", "9.6", "9.8", "9.10", "9.12"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -86,15 +86,15 @@ jobs:
           - "9.0.2"
           - "9.2.8"
           - "9.4.8"
-          - "9.6.6"
+          - "9.6.7"
           - "9.8.4"
-          - "9.10.1"
-          - "9.12.1"
+          - "9.10.3"
+          - "9.12.2"
         project-variant: [""]
         include:
           - ghc: 8.0.2
             project-variant: -lower
-          - ghc: 9.12.1
+          - ghc: 9.14.1
             project-variant: -upper
 
       fail-fast: false

--- a/docopt.cabal
+++ b/docopt.cabal
@@ -18,10 +18,11 @@ tested-with:
   GHC == 9.0.2,
   GHC == 9.2.8,
   GHC == 9.4.8,
-  GHC == 9.6.6,
+  GHC == 9.6.7,
   GHC == 9.8.4,
-  GHC == 9.10.1,
-  GHC == 9.12.1
+  GHC == 9.10.4,
+  GHC == 9.12.2,
+  GHC == 9.14.1
 
 category:            Console
 
@@ -44,7 +45,7 @@ source-repository head
 source-repository this
   type:       git
   location:   https://github.com/docopt/docopt.hs.git
-  tag:        v0.7.0.8+r2
+  tag:        v0.7.0.8+r3
 
 library
   exposed-modules:    System.Console.Docopt.NoTH
@@ -62,7 +63,7 @@ library
   build-depends:      base >= 4.9 && < 5.0,
                       parsec >= 3.1.14 && < 3.2,
                       containers >= 0.6.2 && < 0.9,
-                      template-haskell >= 2.11.0 && < 2.24
+                      template-haskell >= 2.11.0 && < 2.25
 
   ghc-options:        -Wall -Wno-name-shadowing
 


### PR DESCRIPTION
Support GHC 9.14

CI: Bump all Stack and GHC versions to their latest minors. Stack nightly has been bumped to most recent version using 9.12.2 as 9.12.3 turned out to have a serious bug.